### PR TITLE
Fix dump-github when markdown is not present

### DIFF
--- a/packages/dump-github/.eslintrc.js
+++ b/packages/dump-github/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         'operator-linebreak': 'off',
         'implicit-arrow-linebreak': 'off',
         'comma-dangle': 'off',
+        'function-paren-newline': 'off',
     },
     plugins: ['jest'],
 }

--- a/packages/dump-github/.eslintrc.js
+++ b/packages/dump-github/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
         'implicit-arrow-linebreak': 'off',
         'comma-dangle': 'off',
         'function-paren-newline': 'off',
+        'object-curly-newline': 'off',
     },
     plugins: ['jest'],
 }

--- a/packages/dump-github/lib/repositories/Repositories.graphql
+++ b/packages/dump-github/lib/repositories/Repositories.graphql
@@ -6,6 +6,9 @@
           name
           description
           url
+          defaultBranchRef {
+            name
+          }
           homepageUrl
           createdAt
           updatedAt

--- a/packages/dump-github/lib/repositories/index.js
+++ b/packages/dump-github/lib/repositories/index.js
@@ -42,7 +42,7 @@ const createMarkdown = async (repositoryUrl, markdownUrl) => {
 
     const replacement = (match, url) => {
         const isRelative = !/^http.*/g.test(url)
-        return match.replace(url, isRelative ? `${repositoryUrl}/raw/master/${url.replace(/^[./]+/, '')}` : url)
+        return match.replace(url, isRelative ? `${repositoryUrl}/${url.replace(/^[./]+/, '')}` : url)
     }
 
     const source = markdown.source
@@ -59,8 +59,10 @@ const getH1 = (source = '') => {
 }
 
 const create = async ({ node }) => {
-    const cover = await createFile(`${node.url}/raw/master/cover.png`)
-    const readme = await createMarkdown(node.url, `${node.url}/raw/master/README.md`)
+    const repositoryUrl = `${node.url}/raw/${node.defaultBranchRef.name}`
+
+    const cover = await createFile(`${repositoryUrl}/cover.png`)
+    const readme = await createMarkdown(repositoryUrl, `${repositoryUrl}/README.md`)
 
     return {
         ...node,
@@ -69,6 +71,7 @@ const create = async ({ node }) => {
             visible: cover.isPresent === true && readme.isPresent === true && node.isPrivate === false,
             starCount: node.stargazers.totalCount,
             forkCount: node.forkCount,
+            defaultBranch: node.defaultBranchRef.name,
             repositoryTopics: createTopics(node.repositoryTopics),
             cover,
             readme,

--- a/packages/dump-github/lib/repositories/index.js
+++ b/packages/dump-github/lib/repositories/index.js
@@ -36,6 +36,10 @@ const createFile = async (originalUrl) => {
 const createMarkdown = async (repositoryUrl, markdownUrl) => {
     const markdown = await createFile(markdownUrl)
 
+    if (!markdown.source) {
+        return markdown
+    }
+
     const replacement = (match, url) => {
         const isRelative = !/^http.*/g.test(url)
         return match.replace(url, isRelative ? `${repositoryUrl}/raw/master/${url.replace(/^[./]+/, '')}` : url)

--- a/packages/dump-github/lib/repositories/index.test.js
+++ b/packages/dump-github/lib/repositories/index.test.js
@@ -1,5 +1,6 @@
-const nock = require('nock')
 const fs = require('fs')
+
+const { nock, nockNode, nockResponse } = require('../testUtility.test')
 
 const { exportAsJson } = require('./index')
 
@@ -7,115 +8,32 @@ jest.mock('fs')
 
 global.console = { log: jest.fn() }
 
-const response = {
-    data: {
-        viewer: {
-            repositories: {
-                edges: [
-                    {
-                        node: {
-                            name: 'kata.js',
-                            description: 'A collection of katas with JavaScript.',
-                            url: 'https://github.com/marcomontalbano/kata.js',
-                            stargazers: {
-                                totalCount: 2,
-                            },
-                            forkCount: 0,
-                            repositoryTopics: {
-                                edges: [
-                                    {
-                                        node: {
-                                            topic: {
-                                                name: 'kata',
-                                            },
-                                        },
-                                    },
-                                    {
-                                        node: {
-                                            topic: {
-                                                name: 'tdd',
-                                            },
-                                        },
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                ],
-            },
-        },
-    },
-}
-
 describe('Dump GitHub - repositories', () => {
-    const repositories = [...response.data.viewer.repositories.edges]
-    const expectedResult = {
-        ...repositories[0].node,
-        customFields: {
-            title: 'Kata JS',
-            visible: false,
-            starCount: 2,
-            forkCount: 0,
-            repositoryTopics: ['kata', 'tdd'],
-            cover: {
-                originalUrl: 'https://github.com/marcomontalbano/kata.js/raw/master/cover.png',
-                url: 'https://github.com/marcomontalbano/kata.js/raw/master/cover.png',
-                isPresent: false,
-                headers: undefined,
-                source: undefined,
-            },
-            readme: {
-                originalUrl: 'https://github.com/marcomontalbano/kata.js/raw/master/README.md',
-                url: 'https://github.com/marcomontalbano/kata.js/raw/master/README.md',
-                isPresent: true,
-                headers: {
-                    'content-type': 'text/plain',
-                },
-                source: `# Kata JS
-README.md source :)
-[Absolute URL](https://example.com)
-![Relative URL](https://github.com/marcomontalbano/kata.js/raw/master/images/example.png)`,
-            },
-        },
-    }
-
-    beforeEach(() => {
-        nock('https://api.github.com')
-            .persist()
-            .post('/graphql')
-            .reply(200, () => response)
-
-        nock('https://github.com/marcomontalbano/kata.js/raw/master')
-            .persist()
-            .get(/README\.md/)
-            .reply(
-                200,
-                () => `# Kata JS
-README.md source :)
-[Absolute URL](https://example.com)
-![Relative URL](images/example.png)`,
-                { 'content-type': 'text/plain' }
-            )
-
-        nock('https://github.com/marcomontalbano/kata.js/raw/master')
-            .persist()
-            .get(/package\.json/)
-            .reply(200, () => 'package.json source :)', {
-                'content-type': 'text/plain',
-            })
-
-        nock('https://github.com/marcomontalbano/kata.js/raw/master')
-            .persist()
-            .get(/cover\.png/)
-            .reply(404)
-    })
-
-    afterEach(() => {
-        nock.cleanAll()
-    })
-
     describe('exportAsJson()', () => {
+        beforeEach(() => {
+            nock.disableNetConnect()
+        })
+
+        afterEach(() => {
+            fs.writeFileSync.mockClear()
+            nock.cleanAll()
+            nock.enableNetConnect()
+        })
+
         it('should be able to enhance the repository object adding new properties', async () => {
+            const [node, expectedResult] = nockNode('project-a', { readmeStatusCode: 200, coverStatusCode: 200 })
+            nockResponse([node])
+
+            await exportAsJson('.')
+
+            expect(fs.writeFileSync.mock.calls[0][0]).toMatch(/Repositories.json$/)
+            expect(fs.writeFileSync.mock.calls[0][1]).toStrictEqual(JSON.stringify([expectedResult], undefined, 2))
+        })
+
+        it('should not break if markdown is not found', async () => {
+            const [node, expectedResult] = nockNode('project-b', { readmeStatusCode: 404, coverStatusCode: 404 })
+            nockResponse([node])
+
             await exportAsJson('.')
 
             expect(fs.writeFileSync.mock.calls[0][0]).toMatch(/Repositories.json$/)

--- a/packages/dump-github/lib/testUtility.test.js
+++ b/packages/dump-github/lib/testUtility.test.js
@@ -1,11 +1,17 @@
 const nock = require('nock')
 
-const nockNode = (name, { readmeStatusCode = 200, coverStatusCode = 200, isPrivate = true }) => {
+const nockNode = (
+    name,
+    { readmeStatusCode = 200, coverStatusCode = 200, isPrivate = true, defaultBranchName = 'production' }
+) => {
     const node = {
         name,
         isPrivate,
         description: `Description for "${name}".`,
         url: `https://github.com/marcomontalbano/${name}`,
+        defaultBranchRef: {
+            name: defaultBranchName,
+        },
         stargazers: {
             totalCount: 2,
         },
@@ -22,28 +28,29 @@ const nockNode = (name, { readmeStatusCode = 200, coverStatusCode = 200, isPriva
             visible: false,
             starCount: 2,
             forkCount: 0,
+            defaultBranch: defaultBranchName,
             repositoryTopics: ['kata', 'tdd'],
             cover: {
-                originalUrl: `${node.url}/raw/master/cover.png`,
-                url: `${node.url}/raw/master/cover.png`,
+                originalUrl: `${node.url}/raw/${defaultBranchName}/cover.png`,
+                url: `${node.url}/raw/${defaultBranchName}/cover.png`,
                 isPresent: coverStatusCode === 200,
                 headers: coverStatusCode === 200 ? { 'content-type': 'image/gif' } : undefined,
                 source: undefined,
             },
             readme: {
-                originalUrl: `${node.url}/raw/master/README.md`,
-                url: `${node.url}/raw/master/README.md`,
+                originalUrl: `${node.url}/raw/${defaultBranchName}/README.md`,
+                url: `${node.url}/raw/${defaultBranchName}/README.md`,
                 isPresent: readmeStatusCode === 200,
                 headers: readmeStatusCode === 200 ? { 'content-type': 'text/plain' } : undefined,
                 source:
                     readmeStatusCode === 200
-                        ? `# Project Title\nREADME.md source :)\n[Absolute URL](https://example.com)\n![Relative URL](${node.url}/raw/master/images/example.png)`
+                        ? `# Project Title\nREADME.md source :)\n[Absolute URL](https://example.com)\n![Relative URL](${node.url}/raw/${defaultBranchName}/images/example.png)`
                         : undefined,
             },
         },
     }
 
-    nock(`${node.url}/raw/master`)
+    nock(`${node.url}/raw/${defaultBranchName}`)
         .get(/cover\.png/)
         .reply(
             coverStatusCode,

--- a/packages/dump-github/lib/testUtility.test.js
+++ b/packages/dump-github/lib/testUtility.test.js
@@ -1,0 +1,86 @@
+const nock = require('nock')
+
+const nockNode = (name, { readmeStatusCode = 200, coverStatusCode = 200, isPrivate = true }) => {
+    const node = {
+        name,
+        isPrivate,
+        description: `Description for "${name}".`,
+        url: `https://github.com/marcomontalbano/${name}`,
+        stargazers: {
+            totalCount: 2,
+        },
+        forkCount: 0,
+        repositoryTopics: {
+            edges: [{ node: { topic: { name: 'kata' } } }, { node: { topic: { name: 'tdd' } } }],
+        },
+    }
+
+    const expectedResult = {
+        ...node,
+        customFields: {
+            title: readmeStatusCode === 200 ? 'Project Title' : node.name,
+            visible: false,
+            starCount: 2,
+            forkCount: 0,
+            repositoryTopics: ['kata', 'tdd'],
+            cover: {
+                originalUrl: `${node.url}/raw/master/cover.png`,
+                url: `${node.url}/raw/master/cover.png`,
+                isPresent: coverStatusCode === 200,
+                headers: coverStatusCode === 200 ? { 'content-type': 'image/gif' } : undefined,
+                source: undefined,
+            },
+            readme: {
+                originalUrl: `${node.url}/raw/master/README.md`,
+                url: `${node.url}/raw/master/README.md`,
+                isPresent: readmeStatusCode === 200,
+                headers: readmeStatusCode === 200 ? { 'content-type': 'text/plain' } : undefined,
+                source:
+                    readmeStatusCode === 200
+                        ? `# Project Title\nREADME.md source :)\n[Absolute URL](https://example.com)\n![Relative URL](${node.url}/raw/master/images/example.png)`
+                        : undefined,
+            },
+        },
+    }
+
+    nock(`${node.url}/raw/master`)
+        .get(/cover\.png/)
+        .reply(
+            coverStatusCode,
+            () => 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+            { 'content-type': 'image/gif' }
+        )
+        .get(/README\.md/)
+        .reply(
+            readmeStatusCode,
+            () =>
+                '# Project Title\nREADME.md source :)\n[Absolute URL](https://example.com)\n![Relative URL](images/example.png)',
+            { 'content-type': 'text/plain' }
+        )
+
+    return [node, expectedResult]
+}
+
+const nockResponse = (nodes = []) => {
+    nock('https://api.github.com')
+        .post('/graphql')
+        .reply(200, () => ({
+            data: {
+                viewer: {
+                    repositories: {
+                        edges: [...nodes.map((node) => ({ node }))],
+                    },
+                },
+            },
+        }))
+}
+
+describe('', () => {
+    it('', () => {})
+})
+
+module.exports = {
+    nock,
+    nockNode,
+    nockResponse,
+}


### PR DESCRIPTION
* Fixed issue when markdown is not present
* Handled `defaultBranch` from GitHub to fetch the correct markdown and cover. `master` branch is not always the default.
